### PR TITLE
Closes #12: `...` parameters passed incorrectly

### DIFF
--- a/R/base_learner.R
+++ b/R/base_learner.R
@@ -433,7 +433,6 @@ mltrain.baseXGB <- function(object, ...) {
     nthread = 1,
     nrounds = 3,
     verbose = FALSE,
-    silent = 1,
     objective = ifelse(nlevels(object$data[, object$labelindex]) == 2,
                        "binary:logistic", "multi:softprob")
   )

--- a/R/transformation.R
+++ b/R/transformation.R
@@ -36,7 +36,7 @@ utiml_create_model <- function(utiml.object, ...) {
     class(model) <- "emptyModel"
   } else {
     # Call dynamic multilabel model with merged parameters
-    model <- do.call(mltrain, c(list(object = utiml.object), ...))
+    model <- do.call(mltrain, c(list(object = utiml.object), list(...)))
   }
   attr(model, "dataset") <- utiml.object$mldataset
   attr(model, "label") <- utiml.object$labelname
@@ -57,7 +57,8 @@ utiml_predict <- function (predictions, probability) {
 }
 
 utiml_predict_binary_model <- function(model, newdata, ...) {
-  result <- do.call(mlpredict, c(list(model = model, newdata = newdata), ...))
+  result <- do.call(mlpredict, c(list(model = model, newdata = newdata),
+                                 list(...)))
 
   if (any(rownames(result) != rownames(newdata))) {
     where <- paste(attr(model, "dataset"), "/", attr(model, "label"))
@@ -78,7 +79,8 @@ utiml_predict_binary_model <- function(model, newdata, ...) {
 
 utiml_predict_multiclass_model <- function (model, newdata, labels, probability,
                                             ...) {
-  result <- do.call(mlpredict, c(list(model = model, newdata = newdata), ...))
+  result <- do.call(mlpredict, c(list(model = model, newdata = newdata),
+                                 list(...)))
   classes <- do.call(rbind, lapply(
     strsplit(as.character(result$prediction),""), as.numeric)
   )


### PR DESCRIPTION
Two edits here: to `transformation.R`, `...` parameters aren't passed correctly when doing `c(list(object = obj), ...)` to the base classifiers. The ellipsis needs to be wrapped in `list(...)` first -- i.e. rewritten as `c(list(object = obj), list(...))`, otherwise the arguments in `...` are first coerced to a vector. (See `?c`, which clarifies that to combine lists, all objects must be wrapped in `list()`).  

Before this bugfix, training models with parameters that include vectors in them (e.g. for XGBoost, which takes in row-level weights as a vector of doubles) would throw a warning and not be able to use the weights (see #12 for details).

I also remove the `silent` parameter, since that's not used by `xgboost::xgboost()` and just throws a warning when `xgboost` is run.

@rivolli , if you'd be able to review and merge this bugfix, that'd be really helpful to me and my team! The fixes here are relatively minor, so I haven't added unit tests (also since I couldn't find tests specific to different base algorithms, and this one more specifically concerns `XGB`). Let me know if there's anything else you would need from me, thank you!