### PR TITLE
Fix XGB not accepting weights with ECC (addition to #13)

### DIFF
--- a/R/base_learner.R
+++ b/R/base_learner.R
@@ -433,7 +433,6 @@ mltrain.baseXGB <- function(object, ...) {
     nthread = 1,
     nrounds = 3,
     verbose = FALSE,
-    silent = 1,
     objective = ifelse(nlevels(object$data[, object$labelindex]) == 2,
                        "binary:logistic", "multi:softprob")
   )

--- a/R/method_ecc.R
+++ b/R/method_ecc.R
@@ -110,7 +110,14 @@ ecc <- function(mdata,
     ndata <- create_subset(mdata, idx[[iteration]]$rows, idx[[iteration]]$cols)
     chain <- idx[[iteration]]$chain
 
-    ccmodel <- cc(ndata, base.algorithm, chain, ..., cores = cores, seed = seed)
+    args <- list(...)
+    # if rowwise weights are passed to base algorithm, subsample weights
+    if (base.algorithm == "XGB" && "weight" %in% names(args)) {
+      args$weight <- args$weight[idx[[iteration]]$rows]
+    }
+
+    ccmodel <- do.call("cc", c(list(ndata, base.algorithm, chain), args,
+                               list(cores = cores, seed = seed)))
     ccmodel$attrs <- colnames(ndata$dataset[, ndata$attributesIndexes])
     rm(ndata)
 

--- a/R/transformation.R
+++ b/R/transformation.R
@@ -36,7 +36,7 @@ utiml_create_model <- function(utiml.object, ...) {
     class(model) <- "emptyModel"
   } else {
     # Call dynamic multilabel model with merged parameters
-    model <- do.call(mltrain, c(list(object = utiml.object), ...))
+    model <- do.call(mltrain, c(list(object = utiml.object), list(...)))
   }
   attr(model, "dataset") <- utiml.object$mldataset
   attr(model, "label") <- utiml.object$labelname
@@ -57,7 +57,8 @@ utiml_predict <- function (predictions, probability) {
 }
 
 utiml_predict_binary_model <- function(model, newdata, ...) {
-  result <- do.call(mlpredict, c(list(model = model, newdata = newdata), ...))
+  result <- do.call(mlpredict, c(list(model = model, newdata = newdata),
+                                 list(...)))
 
   if (any(rownames(result) != rownames(newdata))) {
     where <- paste(attr(model, "dataset"), "/", attr(model, "label"))
@@ -78,7 +79,8 @@ utiml_predict_binary_model <- function(model, newdata, ...) {
 
 utiml_predict_multiclass_model <- function (model, newdata, labels, probability,
                                             ...) {
-  result <- do.call(mlpredict, c(list(model = model, newdata = newdata), ...))
+  result <- do.call(mlpredict, c(list(model = model, newdata = newdata),
+                                 list(...)))
   classes <- do.call(rbind, lapply(
     strsplit(as.character(result$prediction),""), as.numeric)
   )


### PR DESCRIPTION
This is in addition to the changes made in #13. 

One outstanding issue is with `ecc()`, which (optionally, but by default) subsamples the data, meaning that observation-level weights will be the wrong length after subsampling. 

We can reproduce this issue with this snippet (run on the version of `utiml` in #13, or more specifically my fork with `devtools::install_github("jasonopolis/utiml")`:
``` r
library(utiml)
#> Loading required package: mldr
#> Loading required package: parallel
#> Loading required package: ROCR
library(xgboost)

# generate random rowwise weights for xgboost
testw <- runif(nrow(toyml$dataset))

multilab_weights <-
  ecc(toyml, "XGB", weight = testw, subsample = 0.75,
      nrounds = 500, print_every_n = 500, verbose = T)
#> Error in setinfo.xgb.DMatrix(dtrain, "weight", weight): The length of weights must equal to the number of rows in the input data
```

<sup>Created on 2020-07-31 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

**In this PR**, I update the `ecc()` method to explicitly check for a "weight" parameter when using XGBoost as a base algorithm, and then subsample the weights as well to match the data in each iteration. This fixes the issue -- (can test with the snippet above and `devtools::install_github("jasonopolis/utiml")`).

Again, @rivolli, if you'd be able to review and incorporate this minor change for us we'd really appreciate it, thank you!